### PR TITLE
Fixed metricsPrefix property

### DIFF
--- a/middlewares/prom/index.js
+++ b/middlewares/prom/index.js
@@ -24,6 +24,7 @@ module.exports = strapi => {
         requestSizeBuckets,
         responseSizeBuckets,
         useUniqueHistogramName,
+        metricsPrefix,
         excludeRoutes,
         includeQueryParams
       });


### PR DESCRIPTION
Added missing metrics property in line 27, which is used as prefix on metrics endpoint.